### PR TITLE
Fix: Handle AgentState as dict in main.py

### DIFF
--- a/brd/project_manager.py
+++ b/brd/project_manager.py
@@ -142,7 +142,15 @@ def create_new_project_core_logic(
     # Instantiate AgentState class
     current_conversation_state = AgentState(
         userInput=initial_user_input,
-        thread_id=new_thread_id # Pass thread_id to constructor
-        # Other fields will use defaults from AgentState __init__
+        thread_id=new_thread_id,
+        messages=[],
+        current_brd_content="",
+        clarification_questions_needed=False,
+        clarification_questions=[],
+        current_understanding=initial_user_input, # Initial understanding set to the first user input
+        max_clarification_rounds=3, # Default value for max clarification rounds
+        current_clarification_round=0, # Starts at round 0
+        clarification_questions_pending_answer=False, # No questions pending initially
+        route_condition="" # Initial route condition, can be set by start_node or other logic later
     )
     return project_id, current_conversation_state, config

--- a/main.py
+++ b/main.py
@@ -176,11 +176,11 @@ def main():
                     current_conversation_state = conv_state_loaded # This is now an AgentState instance
 
                     # Update config with thread_id and existing llm_instance
-                    current_thread_id = current_conversation_state.thread_id
+                    current_thread_id = current_conversation_state['thread_id']
                     if not current_thread_id:
                         thread_id_counter += 1
                         current_thread_id = f"brd-cli-thread-{current_project_id}-{thread_id_counter}"
-                        current_conversation_state.thread_id = current_thread_id # Set on the instance
+                        current_conversation_state['thread_id'] = current_thread_id # Set on the instance
                         print(f"WARNING: No Thread ID found in loaded project state object. Generated new one: {current_thread_id}")
                     else:
                         print(f"INFO: Using existing Thread ID from loaded project: {current_thread_id}")
@@ -188,8 +188,8 @@ def main():
                     config = {**base_config, "configurable": {"thread_id": current_thread_id}}
 
 
-                    if not current_conversation_state.messages and \
-                       not current_conversation_state.clarification_questions_pending_answer:
+                    if not current_conversation_state['messages'] and \
+                       not current_conversation_state['clarification_questions_pending_answer']:
                         print(f"\nProject '{current_project_id}' is loaded. It seems to be at an initial state or requires new input.")
                         user_input_for_loaded = get_user_choice(
                             f"Enter your next query or concept for '{current_project_id}' (or 'exit' to return to menu): "
@@ -198,7 +198,7 @@ def main():
                             current_project_id, current_conversation_state = None, None
                             config = {**base_config} # Reset config to base (only llm)
                             continue
-                        current_conversation_state.userInput = user_input_for_loaded # Set on the instance
+                        current_conversation_state['userInput'] = user_input_for_loaded # Set on the instance
                 else:
                     # Error messages are printed by load_project_core_logic
                     print("Returning to main menu.")
@@ -259,7 +259,7 @@ def main():
         # --- Interaction with the Agent Graph ---
         if current_project_id and current_conversation_state: # current_conversation_state is AgentState object
             # Determine if we need to prompt for answers or new input
-            if current_conversation_state.clarification_questions_pending_answer:
+            if current_conversation_state['clarification_questions_pending_answer']:
                 prompt_msg = "\nPlease provide answers to the agent's questions (or type 'exit' to quit project and return to menu): "
                 answers_input = get_user_choice(prompt_msg)
                 if answers_input == "exit":
@@ -268,15 +268,15 @@ def main():
                     config = {**base_config} # Reset config to base (only llm)
                     continue
 
-                current_conversation_state.add_message(HumanMessage(content=answers_input))
-                current_conversation_state.set_answers_pending(False) # Answers provided
+                current_conversation_state['messages'].append(HumanMessage(content=answers_input))
+                current_conversation_state['clarification_questions_pending_answer'] = False # Answers provided
                 print("\nProcessing your answers...")
-            elif not current_conversation_state.messages and current_conversation_state.userInput:
+            elif not current_conversation_state['messages'] and current_conversation_state['userInput']:
                 # First turn of a new project or loaded project that needs initial processing
                 print(f"\nProcessing initial concept for '{current_project_id}'...")
-            elif not current_conversation_state.userInput and \
-                 not current_conversation_state.messages and \
-                 not current_conversation_state.clarification_questions_pending_answer:
+            elif not current_conversation_state['userInput'] and \
+                 not current_conversation_state['messages'] and \
+                 not current_conversation_state['clarification_questions_pending_answer']:
                 # Loaded an empty or minimal project state, needs initial concept.
                 user_input_concept = get_user_choice( # Renamed to avoid conflict
                     f"Project '{current_project_id}' is empty. Enter your high-level concept or BRD idea (or 'exit' to return to menu): "
@@ -286,7 +286,7 @@ def main():
                     current_project_id, current_conversation_state = None, None
                     config = {**base_config} # Reset config to base (only llm)
                     continue
-                current_conversation_state.userInput = user_input_concept # Set on the instance
+                current_conversation_state['userInput'] = user_input_concept # Set on the instance
                 print(f"\nProcessing initial concept for '{current_project_id}'...")
             # Else: graph has messages and is not pending questions, it might be continuing a completed task.
             # The user will be prompted *after* this graph.invoke if no questions are asked.
@@ -303,28 +303,28 @@ def main():
                     # Ensure thread_id from config is saved back to state object if it was newly generated for loaded project
                     # This should already be handled if current_conversation_state.thread_id was set.
                     # config_thread_id = config.get("configurable", {}).get("thread_id")
-                    # if config_thread_id and current_conversation_state.thread_id != config_thread_id:
-                    #    current_conversation_state.thread_id = config_thread_id # Ensure consistency
+                    # if config_thread_id and current_conversation_state['thread_id'] != config_thread_id:
+                    #    current_conversation_state['thread_id'] = config_thread_id # Ensure consistency
 
-                    save_project(current_project_id, current_conversation_state.to_dict()) # Convert to dict for saving
+                    save_project(current_project_id, current_conversation_state) # Convert to dict for saving
                     print(f"Project '{current_project_id}' saved successfully.")
 
                 print("\n--- Conversation Update ---")
-                if final_state_obj and final_state_obj.messages:
-                    for msg in final_state_obj.messages:
+                if final_state_obj and final_state_obj['messages']:
+                    for msg in final_state_obj['messages']:
                         if isinstance(msg, HumanMessage): print(f"  YOU: {msg.content}")
                         elif isinstance(msg, AIMessage): print(f"  AGENT: {msg.content}")
                         else: print(f"  {msg.type.upper()}: {str(msg.content if hasattr(msg, 'content') else msg)}")
                 else:
                     print("No messages in the current state to display.")
 
-                if final_state_obj.clarification_questions_pending_answer:
+                if final_state_obj['clarification_questions_pending_answer']:
                     # Agent asked questions (printed above). Loop will prompt for answers.
                     pass
                 else: # Agent phase complete (BRD generated or error occurred and handled by agent)
                     print("\n--- Agent Interaction Complete for this phase ---")
-                    brd_content_output = final_state_obj.current_brd_content
-                    agent_messages_list = final_state_obj.messages # Renamed to avoid conflict
+                    brd_content_output = final_state_obj['current_brd_content']
+                    agent_messages_list = final_state_obj['messages'] # Renamed to avoid conflict
                     last_ai_message_content = ""
                     if agent_messages_list and isinstance(agent_messages_list[-1], AIMessage):
                         last_ai_message_content = agent_messages_list[-1].content or ""
@@ -379,8 +379,8 @@ def main():
                             current_project_id, current_conversation_state = None, None
                             config = {**base_config} # Reset config
                             continue
-                        current_conversation_state.userInput = user_input_refine
-                        current_conversation_state.set_brd_content("") # Clear old BRD
+                        current_conversation_state['userInput'] = user_input_refine
+                        current_conversation_state['current_brd_content'] = "" # Clear old BRD
                         # messages list is handled by add_message or graph itself.
                     elif next_action == 'n' or next_action == 'l':
                         current_project_id, current_conversation_state = None, None


### PR DESCRIPTION
The current_conversation_state, which conforms to the AgentState TypedDict, was being accessed using object attribute notation (e.g., state.attribute) and method calls (e.g., state.add_message()) in main.py. However, since AgentState is a TypedDict, it should be treated as a dictionary.

This commit refactors main.py to:
- Use dictionary key access (e.g., state['attribute']) for reading and writing to current_conversation_state and final_state_obj.
- Replace pseudo-method calls like .add_message() with direct dictionary manipulations (e.g., state['messages'].append()).
- Corrects the save_project() call to pass current_conversation_state directly, as it's already a dictionary, removing the erroneous .to_dict() call.

Additionally, brd/project_manager.py was updated to ensure that create_new_project_core_logic fully initializes new AgentState dictionaries with all fields defined in the TypedDict, preventing potential KeyErrors downstream, especially for the 'messages' list.