### PR TITLE
Fix: Ensure you are prompted when OPENAI_API_KEY is missing

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,8 +78,16 @@ def main():
         print("OPENAI_API_KEY='your_actual_api_key'")
         print("=" * 60 + "\n")
 
-        user_choice_continue = 'y' # Automatically proceed without API key for testing
-        if user_choice_continue == 'n' or user_choice_continue == 'exit':
+        user_choice_continue = get_user_choice(
+            "CRITICAL WARNING: OPENAI_API_KEY environment variable not found!\n"
+            "The agent will NOT be able to communicate with the OpenAI API.\n"
+            "Please set it up immediately. You can create a '.env' file in the\n"
+            "project root with the following content (replace with your actual key):\n"
+            "OPENAI_API_KEY='your_actual_api_key'\n\n"
+            "Do you want to continue without the API key? (Y/N): ",
+            ['y', 'n', 'yes', 'no']  # get_user_choice ensures one of these or 'exit'
+        )
+        if user_choice_continue == 'n' or user_choice_continue == 'no' or user_choice_continue == 'exit':
             print("Exiting. Please configure the OPENAI_API_KEY.")
             return
         print("WARNING: Continuing without API key. Expect errors related to OpenAI API calls.")


### PR DESCRIPTION
Previously, `main.py` had a hardcoded behavior to automatically proceed with a warning if the `OPENAI_API_KEY` environment variable was not found. This often led to the application running and then failing only when an LLM call was attempted, as reported in the original issue.

This commit modifies `main.py` to:
- Remove the hardcoded `user_choice_continue = 'y'`.
- Utilize the `get_user_choice` function to explicitly ask you if you want to continue without the API key or exit.
- The warning message displayed is comprehensive, guiding you on how to set the API key.
- The program now correctly exits if you choose not to proceed without the key.

This change ensures that you are made aware of critical missing configuration at startup and can choose to rectify it before encountering runtime errors related to LLM calls.